### PR TITLE
Improved BackendType, various fixes

### DIFF
--- a/silicon-api/src/main/java/org/silicon/api/Silicon.java
+++ b/silicon-api/src/main/java/org/silicon/api/Silicon.java
@@ -14,7 +14,7 @@ import java.util.ServiceLoader;
  */
 public class Silicon {
 
-    private static ComputeBackend backend;
+    private static volatile ComputeBackend backend;
 
     /**
      * Explicitly selects a backend by type.

--- a/silicon-api/src/main/java/org/silicon/api/backend/BackendType.java
+++ b/silicon-api/src/main/java/org/silicon/api/backend/BackendType.java
@@ -6,29 +6,31 @@ package org.silicon.api.backend;
  * Lower priority value means preferred during auto-selection.
  */
 public enum BackendType {
-    CUDA("CUDA", 0),
-    METAL("Metal", 1),
-    OPENCL("OpenCL", 2);
-    
-    private final String name;
-    private final int priority;
-    
-    BackendType(String name, int priority) {
-        this.name = name;
-        this.priority = priority;
+
+    CUDA("CUDA", "ptx"),
+    METAL("METAL", "metal"),
+    OPENCL("OPENCL", null);
+
+    private final String formalName, compileTarget;
+
+    BackendType(String formalName, String compileTarget) {
+        this.formalName = formalName;
+        this.compileTarget = compileTarget;
     }
 
-    /**
-     * @return human-readable backend name
-     */
     public String formalName() {
-        return name;
+        return formalName;
     }
-    
-    /**
-     * @return lower value means higher priority during auto-selection
-     */
+
+    public String compileTarget() {
+        if (compileTarget == null) {
+            throw new IllegalStateException(formalName + " is not supported yet.");
+        }
+        return compileTarget;
+    }
+
     public int priority() {
-        return priority;
+        return ordinal();
     }
+
 }

--- a/silicon-api/src/main/java/org/silicon/api/device/ComputeArena.java
+++ b/silicon-api/src/main/java/org/silicon/api/device/ComputeArena.java
@@ -29,8 +29,8 @@ public class ComputeArena implements AutoCloseable {
 
     @Override
     public void close() {
-        for (Freeable object : retained) {
-            object.free();
+        for (int i = retained.size() - 1; i >= 0; i--) {
+            retained.get(i).free();
         }
     }
 

--- a/silicon-api/src/main/java/org/silicon/api/device/ComputeContext.java
+++ b/silicon-api/src/main/java/org/silicon/api/device/ComputeContext.java
@@ -1,8 +1,9 @@
 package org.silicon.api.device;
 
+import org.silicon.api.SiliconException;
 import org.silicon.api.backend.BackendType;
-import org.silicon.api.kernel.ComputeQueue;
 import org.silicon.api.function.ComputeModule;
+import org.silicon.api.kernel.ComputeQueue;
 
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -30,7 +31,7 @@ public interface ComputeContext {
             byte[] src = in.readAllBytes();
             return loadModule(src);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new SiliconException("loadModuleFromResources(String) failed", e);
         }
     }
 

--- a/silicon-api/src/main/java/org/silicon/api/kernel/ComputeArgs.java
+++ b/silicon-api/src/main/java/org/silicon/api/kernel/ComputeArgs.java
@@ -4,6 +4,7 @@ import org.silicon.api.device.ComputeBuffer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -51,7 +52,7 @@ public class ComputeArgs {
      * @return the underlying argument list (in order)
      */
     public List<Object> getArgs() {
-        return args;
+        return Collections.unmodifiableList(args);
     }
 
     /**

--- a/silicon-cuda/src/main/java/org/silicon/cuda/CUDA.java
+++ b/silicon-cuda/src/main/java/org/silicon/cuda/CUDA.java
@@ -88,7 +88,7 @@ public class CUDA implements ComputeBackend {
             MemorySegment ptr = (MemorySegment) CUDA_CREATE_SYSTEM_DEVICE.invokeExact(index);
             
             if (ptr == null || ptr.address() == 0) {
-                throw new RuntimeException("cuDeviceGet failed");
+                throw new SiliconException("cuDeviceGet failed");
             }
             
             return new CudaDevice(ptr, index);

--- a/silicon-cuda/src/main/java/org/silicon/cuda/device/CudaBuffer.java
+++ b/silicon-cuda/src/main/java/org/silicon/cuda/device/CudaBuffer.java
@@ -97,7 +97,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
 
         try {
             int res = (int) CUDA_MEMCPY_DTOD.invoke(buffer.handle, handle, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyDtoD failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyDtoD failed: " + res);
 
             return buffer;
         } catch (Throwable e) {
@@ -116,7 +116,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
         
         try {
             int res = (int) CUDA_MEM_FREE.invoke(handle);
-            if (res != 0) throw new RuntimeException("cuMemFree failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemFree failed: " + res);
 
             state = MemoryState.FREE;
         } catch (Throwable e) {
@@ -133,7 +133,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocate(ValueLayout.JAVA_BYTE, data.length);
 
             int res = (int) CUDA_MEMCPY_DTOH.invoke(host, handle, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyDtoH failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyDtoH failed: " + res);
 
             MemorySegment.copy(host, 0, MemorySegment.ofArray(data), 0, size);
         } catch (Throwable e) {
@@ -150,7 +150,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocate(ValueLayout.JAVA_DOUBLE, data.length);
 
             int res = (int) CUDA_MEMCPY_DTOH.invoke(host, handle, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyDtoH failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyDtoH failed: " + res);
 
             MemorySegment.copy(host, 0, MemorySegment.ofArray(data), 0, size);
         } catch (Throwable e) {
@@ -167,7 +167,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocate(ValueLayout.JAVA_FLOAT, data.length);
 
             int res = (int) CUDA_MEMCPY_DTOH.invoke(host, handle, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyDtoH failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyDtoH failed: " + res);
 
             MemorySegment.copy(host, 0, MemorySegment.ofArray(data), 0, size);
         } catch (Throwable e) {
@@ -184,7 +184,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocate(ValueLayout.JAVA_LONG, data.length);
 
             int res = (int) CUDA_MEMCPY_DTOH.invoke(host, handle, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyDtoH failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyDtoH failed: " + res);
 
             MemorySegment.copy(host, 0, MemorySegment.ofArray(data), 0, size);
         } catch (Throwable e) {
@@ -201,7 +201,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocate(ValueLayout.JAVA_INT, data.length);
 
             int res = (int) CUDA_MEMCPY_DTOH.invoke(host, handle, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyDtoH failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyDtoH failed: " + res);
 
             MemorySegment.copy(host, 0, MemorySegment.ofArray(data), 0, size);
         } catch (Throwable e) {
@@ -218,7 +218,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocate(ValueLayout.JAVA_SHORT, data.length);
 
             int res = (int) CUDA_MEMCPY_DTOH.invoke(host, handle, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyDtoH failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyDtoH failed: " + res);
 
             MemorySegment.copy(host, 0, MemorySegment.ofArray(data), 0, size);
         } catch (Throwable e) {
@@ -240,7 +240,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocateFrom(ValueLayout.JAVA_BYTE, data);
 
             int res = (int) CUDA_MEMCPY_HTOD.invoke(handle, host, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyHtoD failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyHtoD failed: " + res);
         } catch (Throwable e) {
             throw new SiliconException("copyToDevice(byte[]) failed", e);
         }
@@ -254,7 +254,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocateFrom(ValueLayout.JAVA_DOUBLE, data);
 
             int res = (int) CUDA_MEMCPY_HTOD.invoke(handle, host, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyHtoD failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyHtoD failed: " + res);
         } catch (Throwable e) {
             throw new SiliconException("copyToDevice(double[]) failed", e);
         }
@@ -268,7 +268,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocateFrom(ValueLayout.JAVA_FLOAT, data);
 
             int res = (int) CUDA_MEMCPY_HTOD.invoke(handle, host, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyHtoD failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyHtoD failed: " + res);
         } catch (Throwable e) {
             throw new SiliconException("copyToDevice(float[]) failed", e);
         }
@@ -282,7 +282,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocateFrom(ValueLayout.JAVA_LONG, data);
 
             int res = (int) CUDA_MEMCPY_HTOD.invoke(handle, host, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyHtoD failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyHtoD failed: " + res);
         } catch (Throwable e) {
             throw new SiliconException("copyToDevice(long[]) failed", e);
         }
@@ -296,7 +296,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocateFrom(ValueLayout.JAVA_INT, data);
 
             int res = (int) CUDA_MEMCPY_HTOD.invoke(handle, host, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyHtoD failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyHtoD failed: " + res);
         } catch (Throwable e) {
             throw new SiliconException("copyToDevice(int[]) failed", e);
         }
@@ -310,7 +310,7 @@ public class CudaBuffer implements CudaObject, ComputeBuffer, Freeable {
             MemorySegment host = arena.allocateFrom(ValueLayout.JAVA_SHORT, data);
 
             int res = (int) CUDA_MEMCPY_HTOD.invoke(handle, host, size);
-            if (res != 0) throw new RuntimeException("cuMemcpyHtoD failed: " + res);
+            if (res != 0) throw new SiliconException("cuMemcpyHtoD failed: " + res);
         } catch (Throwable e) {
             throw new SiliconException("copyToDevice(short[]) failed", e);
         }

--- a/silicon-cuda/src/main/java/org/silicon/cuda/device/CudaDevice.java
+++ b/silicon-cuda/src/main/java/org/silicon/cuda/device/CudaDevice.java
@@ -39,7 +39,7 @@ public record CudaDevice(MemorySegment handle, int index) implements CudaObject,
             MemorySegment ctx = (MemorySegment) CUDA_CREATE_CONTEXT.invoke(handle());
 
             if (ctx == null || ctx.address() == 0) {
-                throw new RuntimeException("Failed to create CUDA context");
+                throw new SiliconException("Failed to create CUDA context");
             }
 
             return new CudaContext(ctx, this).setCurrent();

--- a/silicon-cuda/src/main/java/org/silicon/cuda/function/CudaFunction.java
+++ b/silicon-cuda/src/main/java/org/silicon/cuda/function/CudaFunction.java
@@ -1,7 +1,8 @@
 package org.silicon.cuda.function;
 
-import org.silicon.cuda.CudaObject;
+import org.silicon.api.SiliconException;
 import org.silicon.api.function.ComputeFunction;
+import org.silicon.cuda.CudaObject;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
@@ -20,7 +21,7 @@ public record CudaFunction(MemorySegment handle) implements CudaObject, ComputeF
         try {
             return (int) CUDA_FUNC_MAX_THREADS.invokeExact(handle);
         } catch (Throwable e) {
-            throw new RuntimeException("maxWorkGroupSize() failed", e);
+            throw new SiliconException("maxWorkGroupSize() failed", e);
         }
     }
 }

--- a/silicon-cuda/src/main/java/org/silicon/cuda/function/CudaModule.java
+++ b/silicon-cuda/src/main/java/org/silicon/cuda/function/CudaModule.java
@@ -25,7 +25,7 @@ public record CudaModule(MemorySegment handle, CudaContext context) implements C
             MemorySegment funcHandle = (MemorySegment) CUDA_MODULE_GET_FUNCTION.invoke(handle, cName);
 
             if (funcHandle == null || funcHandle.address() == 0) {
-                throw new RuntimeException("Failed to get function: " + name);
+                throw new SiliconException("Failed to get function: " + name);
             }
 
             return new CudaFunction(funcHandle);

--- a/silicon-cuda/src/main/java/org/silicon/cuda/kernel/CudaEvent.java
+++ b/silicon-cuda/src/main/java/org/silicon/cuda/kernel/CudaEvent.java
@@ -63,7 +63,7 @@ public class CudaEvent implements ComputeEvent {
             
             int res = (int) CUDA_EVENT_RECORD.invokeExact(event, stream.handle());
             if (res != 0) {
-                throw new RuntimeException("cuEventRecord failed: " + res);
+                throw new SiliconException("cuEventRecord failed: " + res);
             }
             
             Thread.startVirtualThread(this::waitAndComplete);
@@ -92,7 +92,7 @@ public class CudaEvent implements ComputeEvent {
     public void await() {
         try {
             int result = (int) CUDA_EVENT_SYNCHRONIZE.invokeExact(event);
-            if (result != 0) throw new RuntimeException("cuEventSynchronize failed: " + result);
+            if (result != 0) throw new SiliconException("cuEventSynchronize failed: " + result);
         } catch (Throwable t) {
             throw new SiliconException("await() failed", t);
         }
@@ -102,7 +102,7 @@ public class CudaEvent implements ComputeEvent {
         if (destroyed.compareAndSet(false, true)) {
             try {
                 int result = (int) CUDA_EVENT_DESTROY.invokeExact(event);
-                if (result != 0) throw new RuntimeException("cuEventDestroy failed: " + result);
+                if (result != 0) throw new SiliconException("cuEventDestroy failed: " + result);
             } catch (Throwable t) {
                 throw new SiliconException("destroy() failed", t);
             }

--- a/silicon-cuda/src/main/java/org/silicon/cuda/kernel/CudaStream.java
+++ b/silicon-cuda/src/main/java/org/silicon/cuda/kernel/CudaStream.java
@@ -88,7 +88,7 @@ public final class CudaStream implements CudaObject, ComputeQueue, Freeable {
             );
 
             if (result != 0) {
-                throw new RuntimeException("cuLaunchKernel failed: " + result);
+                throw new SiliconException("cuLaunchKernel failed: " + result);
             }
         } catch (Throwable e) {
             throw new SiliconException("dispatch(ComputeFunction, ComputeSize, ComputeSize, ComputeArgs) failed", e);
@@ -135,7 +135,7 @@ public final class CudaStream implements CudaObject, ComputeQueue, Freeable {
             );
             
             if (result != 0) {
-                throw new RuntimeException("cuLaunchKernel failed: " + result);
+                throw new SiliconException("cuLaunchKernel failed: " + result);
             }
             
             return new CudaEvent(this);
@@ -172,7 +172,7 @@ public final class CudaStream implements CudaObject, ComputeQueue, Freeable {
 
         try {
             int res = (int) CUDA_STREAM_SYNC.invoke(handle);
-            if (res != 0) throw new RuntimeException("cuStreamSynchronized failed: " + res);
+            if (res != 0) throw new SiliconException("cuStreamSynchronized failed: " + res);
         } catch (Throwable e) {
             throw new SiliconException("awaitCompletion() failed", e);
         }
@@ -189,7 +189,7 @@ public final class CudaStream implements CudaObject, ComputeQueue, Freeable {
 
         try {
             int res = (int) CUDA_STREAM_DESTROY.invoke(handle);
-            if (res != 0) throw new RuntimeException("cuStreamDestroy failed: " + res);
+            if (res != 0) throw new SiliconException("cuStreamDestroy failed: " + res);
             
             state = MemoryState.FREE;
         } catch (Throwable e) {

--- a/silicon-metal/src/main/java/org/silicon/metal/Metal.java
+++ b/silicon-metal/src/main/java/org/silicon/metal/Metal.java
@@ -21,7 +21,6 @@ public class Metal implements ComputeBackend {
 
     static {
         LOOKUP = loadFromResources("/libmetal4j.dylib");
-        System.out.println("look: " + LOOKUP);
 
         if (LOOKUP != null) {
             METAL_CREATE_SYSTEM_DEVICE = MetalObject.find(

--- a/silicon-metal/src/main/java/org/silicon/metal/Metal.java
+++ b/silicon-metal/src/main/java/org/silicon/metal/Metal.java
@@ -21,6 +21,7 @@ public class Metal implements ComputeBackend {
 
     static {
         LOOKUP = loadFromResources("/libmetal4j.dylib");
+        System.out.println("look: " + LOOKUP);
 
         if (LOOKUP != null) {
             METAL_CREATE_SYSTEM_DEVICE = MetalObject.find(
@@ -57,7 +58,7 @@ public class Metal implements ComputeBackend {
             MemorySegment ptr = (MemorySegment) METAL_CREATE_SYSTEM_DEVICE.invokeExact();
             
             if (ptr == null || ptr.address() == 0) {
-                throw new RuntimeException("metalCreateSystemDevice failed");
+                throw new SiliconException("metalCreateSystemDevice failed");
             }
             
             return new MetalDevice(ptr);

--- a/silicon-metal/src/main/java/org/silicon/metal/device/MetalContext.java
+++ b/silicon-metal/src/main/java/org/silicon/metal/device/MetalContext.java
@@ -53,7 +53,7 @@ public record MetalContext(MetalDevice device) implements MetalObject, ComputeCo
             MemorySegment queuePtr = (MemorySegment) METAL_CREATE_COMMAND_QUEUE.invokeExact(device.handle());
 
             if (queuePtr == null) {
-                throw new RuntimeException("Failed to create Metal command queue");
+                throw new SiliconException("Failed to create Metal command queue");
             }
 
             return new MetalCommandQueue(queuePtr, arena);
@@ -83,7 +83,7 @@ public record MetalContext(MetalDevice device) implements MetalObject, ComputeCo
             MemorySegment libPtr = (MemorySegment) METAL_CREATE_LIBRARY.invokeExact(device.handle(), src);
 
             if (libPtr == null) {
-                throw new RuntimeException("Failed to compile Metal library");
+                throw new SiliconException("Failed to compile Metal library");
             }
 
             return new MetalLibrary(libPtr);
@@ -98,7 +98,7 @@ public record MetalContext(MetalDevice device) implements MetalObject, ComputeCo
             MemorySegment ptr = (MemorySegment) METAL_NEW_BUFFER.invokeExact(device.handle(), size);
             
             if (ptr == null || ptr.address() == 0) {
-                throw new RuntimeException("metalMakeBuffer failed");
+                throw new SiliconException("metalMakeBuffer failed");
             }
             
             return new MetalBuffer(ptr, this, size);
@@ -116,35 +116,35 @@ public record MetalContext(MetalDevice device) implements MetalObject, ComputeCo
 
     @Override
     public ComputeBuffer allocateArray(double[] data) {
-        long size = data.length * 8L;
+        long size = data.length * ValueLayout.JAVA_DOUBLE.byteSize();
         MemorySegment srcSeg = MemorySegment.ofArray(data);
         return allocateFromArray(srcSeg, size);
     }
 
     @Override
     public ComputeBuffer allocateArray(float[] data) {
-        long size = data.length * 4L;
+        long size = data.length * ValueLayout.JAVA_FLOAT.byteSize();
         MemorySegment srcSeg = MemorySegment.ofArray(data);
         return allocateFromArray(srcSeg, size);
     }
 
     @Override
     public ComputeBuffer allocateArray(long[] data) {
-        long size = data.length * 8L;
+        long size = data.length * ValueLayout.JAVA_LONG.byteSize();
         MemorySegment srcSeg = MemorySegment.ofArray(data);
         return allocateFromArray(srcSeg, size);
     }
-    
+
     @Override
     public ComputeBuffer allocateArray(int[] data) {
-        long size = data.length * 4L;
+        long size = data.length * ValueLayout.JAVA_INT.byteSize();
         MemorySegment srcSeg = MemorySegment.ofArray(data);
         return allocateFromArray(srcSeg, size);
     }
 
     @Override
     public ComputeBuffer allocateArray(short[] data) {
-        long size = data.length * 2L;
+        long size = data.length * ValueLayout.JAVA_SHORT.byteSize();
         MemorySegment srcSeg = MemorySegment.ofArray(data);
         return allocateFromArray(srcSeg, size);
     }

--- a/silicon-metal/src/main/java/org/silicon/metal/function/MetalLibrary.java
+++ b/silicon-metal/src/main/java/org/silicon/metal/function/MetalLibrary.java
@@ -26,7 +26,7 @@ public record MetalLibrary(MemorySegment handle) implements MetalObject, Compute
             MemorySegment fnPtr = (MemorySegment) METAL_CREATE_FUNCTION.invokeExact(handle, fnName);
 
             if (fnPtr == null || fnPtr.address() == 0) {
-                throw new RuntimeException("Function '" + name + "' not found in library");
+                throw new SiliconException("Function '" + name + "' not found in library");
             }
 
             return new MetalFunction(fnPtr);

--- a/silicon-metal/src/main/java/org/silicon/metal/kernel/MetalCommandBuffer.java
+++ b/silicon-metal/src/main/java/org/silicon/metal/kernel/MetalCommandBuffer.java
@@ -38,7 +38,7 @@ public final class MetalCommandBuffer implements MetalObject, Freeable {
             MemorySegment ptr = (MemorySegment) METAL_MAKE_ENCODER.invokeExact(handle, pipeline.handle());
 
             if (ptr == null || ptr.address() == 0) {
-                throw new RuntimeException("makeComputeCommandEncoder failed");
+                throw new SiliconException("makeComputeCommandEncoder failed");
             }
 
             return new MetalEncoder(ptr);

--- a/silicon-metal/src/main/java/org/silicon/metal/kernel/MetalCommandQueue.java
+++ b/silicon-metal/src/main/java/org/silicon/metal/kernel/MetalCommandQueue.java
@@ -124,7 +124,7 @@ public final class MetalCommandQueue implements MetalObject, ComputeQueue, Freea
             MemorySegment ptr = (MemorySegment) METAL_CREATE_COMMAND_BUFFER.invokeExact(handle);
             
             if (ptr == null || ptr.address() == 0) {
-                throw new RuntimeException("metalMakeCommandBuffer failed");
+                throw new SiliconException("metalMakeCommandBuffer failed");
             }
             
             return new MetalCommandBuffer(ptr);

--- a/silicon-metal/src/main/java/org/silicon/metal/kernel/MetalEncoder.java
+++ b/silicon-metal/src/main/java/org/silicon/metal/kernel/MetalEncoder.java
@@ -125,7 +125,7 @@ public final class MetalEncoder implements MetalObject, AutoCloseable {
         try {
             endEncoding();
         } catch (Throwable e) {
-            throw new RuntimeException(e);
+            throw new SiliconException(e);
         }
     }
 

--- a/silicon-opencl/src/main/java/org/silicon/opencl/OpenCL.java
+++ b/silicon-opencl/src/main/java/org/silicon/opencl/OpenCL.java
@@ -3,6 +3,7 @@ package org.silicon.opencl;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.opencl.CL10;
 import org.lwjgl.system.MemoryStack;
+import org.silicon.api.SiliconException;
 import org.silicon.api.backend.BackendType;
 import org.silicon.api.backend.ComputeBackend;
 import org.silicon.api.device.ComputeDevice;
@@ -17,7 +18,7 @@ public class OpenCL implements ComputeBackend {
             IntBuffer buffer = stack.mallocInt(1);
             
             int result = CL10.clGetPlatformIDs(null, buffer);
-            if (result != CL10.CL_SUCCESS) throw new RuntimeException("clGetPlatformIDs failed: " + result);
+            if (result != CL10.CL_SUCCESS) throw new SiliconException("clGetPlatformIDs failed: " + result);
             
             return buffer.get(0);
         } catch (Exception e) {
@@ -30,7 +31,7 @@ public class OpenCL implements ComputeBackend {
             PointerBuffer platforms = stack.mallocPointer(platformCount);
             
             int result = CL10.clGetPlatformIDs(platforms, (IntBuffer) null);
-            if (result != CL10.CL_SUCCESS) throw new RuntimeException("clGetPlatformIDs failed: " + result);
+            if (result != CL10.CL_SUCCESS) throw new SiliconException("clGetPlatformIDs failed: " + result);
             
             return platforms.get(0);
         } catch (Exception e) {
@@ -47,7 +48,7 @@ public class OpenCL implements ComputeBackend {
             IntBuffer numDevices = stack.mallocInt(1);
             
             int result = CL10.clGetDeviceIDs(platform, CL10.CL_DEVICE_TYPE_GPU, null, numDevices);
-            if (result != CL10.CL_SUCCESS) throw new RuntimeException("clGetDeviceIDs failed: " + result);
+            if (result != CL10.CL_SUCCESS) throw new SiliconException("clGetDeviceIDs failed: " + result);
             
             return numDevices.get(0);
         } catch (Exception e) {
@@ -81,7 +82,7 @@ public class OpenCL implements ComputeBackend {
             PointerBuffer devices = stack.mallocPointer(deviceCount);
             
             int result = CL10.clGetDeviceIDs(platform, CL10.CL_DEVICE_TYPE_GPU, devices, (IntBuffer)null);
-            if (result != CL10.CL_SUCCESS) throw new RuntimeException("clGetDeviceIDs failed: " + result);
+            if (result != CL10.CL_SUCCESS) throw new SiliconException("clGetDeviceIDs failed: " + result);
             
             long device = devices.get(index);
             return new CLDevice(device, platform);

--- a/silicon-opencl/src/main/java/org/silicon/opencl/device/CLBuffer.java
+++ b/silicon-opencl/src/main/java/org/silicon/opencl/device/CLBuffer.java
@@ -1,9 +1,10 @@
 package org.silicon.opencl.device;
 
 import org.lwjgl.opencl.CL10;
-import org.silicon.api.memory.MemoryState;
-import org.silicon.api.kernel.ComputeQueue;
+import org.silicon.api.SiliconException;
 import org.silicon.api.device.ComputeBuffer;
+import org.silicon.api.kernel.ComputeQueue;
+import org.silicon.api.memory.MemoryState;
 import org.silicon.opencl.computing.CLCommandQueue;
 
 import java.nio.ByteBuffer;
@@ -41,7 +42,7 @@ public class CLBuffer implements ComputeBuffer {
             queue.handle(), buffer.getHandle(), handle,
             0, 0, size, null, null
         );
-        if (res != 0) throw new RuntimeException("clEnqueueCopyBuffer failed: " + res);
+        if (res != 0) throw new SiliconException("clEnqueueCopyBuffer failed: " + res);
         
         queue.await();
         queue.free();
@@ -59,7 +60,7 @@ public class CLBuffer implements ComputeBuffer {
         if (state != MemoryState.ALIVE) return;
 
         int res = CL10.clReleaseMemObject(handle);
-        if (res != 0) throw new RuntimeException("clReleaseMemObject failed: " + res);
+        if (res != 0) throw new SiliconException("clReleaseMemObject failed: " + res);
 
         state = MemoryState.FREE;
     }
@@ -143,7 +144,7 @@ public class CLBuffer implements ComputeBuffer {
             .order(ByteOrder.nativeOrder());
 
         int res = CL10.clEnqueueReadBuffer(queue.handle(), handle, true, 0, buffer, null, null);
-        if (res != 0) throw new RuntimeException("clEnqueueReadBuffer failed: " + res);
+        if (res != 0) throw new SiliconException("clEnqueueReadBuffer failed: " + res);
 
         return new Result(queue, buffer);
     }

--- a/silicon-opencl/src/main/java/org/silicon/opencl/device/CLContext.java
+++ b/silicon-opencl/src/main/java/org/silicon/opencl/device/CLContext.java
@@ -48,7 +48,7 @@ public record CLContext(long handle, long device) implements ComputeContext {
             IntBuffer result = stack.mallocInt(1);
 
             long queue = CL10.clCreateCommandQueue(handle, device, 0, result);
-            if (result.get(0) != CL10.CL_SUCCESS) throw new RuntimeException("clCreateCommandQueue failed: " + result.get(0));
+            if (result.get(0) != CL10.CL_SUCCESS) throw new SiliconException("clCreateCommandQueue failed: " + result.get(0));
 
             return new CLCommandQueue(queue);
         }
@@ -74,13 +74,13 @@ public record CLContext(long handle, long device) implements ComputeContext {
             IntBuffer result = stack.mallocInt(1);
             long program = CL10.clCreateProgramWithSource(handle, source, result);
             
-            if (program == 0L) throw new RuntimeException("clCreateProgramWithSource returned null");
+            if (program == 0L) throw new SiliconException("clCreateProgramWithSource returned null");
             if (result.get(0) != CL10.CL_SUCCESS) {
-                throw new RuntimeException("clCreateProgramWithSource failed: " + result.get(0));
+                throw new SiliconException("clCreateProgramWithSource failed: " + result.get(0));
             }
             
             int buildErr = CL10.clBuildProgram(program, device, "", null, 0);
-            if (buildErr != CL10.CL_SUCCESS) throw new RuntimeException("clBuildProgram failed: " + buildErr);
+            if (buildErr != CL10.CL_SUCCESS) throw new SiliconException("clBuildProgram failed: " + buildErr);
             
             return new CLProgram(program, device);
         }

--- a/silicon-opencl/src/main/java/org/silicon/opencl/device/CLDevice.java
+++ b/silicon-opencl/src/main/java/org/silicon/opencl/device/CLDevice.java
@@ -3,6 +3,7 @@ package org.silicon.opencl.device;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.opencl.CL10;
 import org.lwjgl.system.MemoryStack;
+import org.silicon.api.SiliconException;
 import org.silicon.api.device.ComputeContext;
 import org.silicon.api.device.ComputeDevice;
 import org.silicon.api.device.DeviceFeature;
@@ -24,7 +25,7 @@ public record CLDevice(long handle, long platform) implements ComputeDevice {
             properties.flip();
 
             long context = CL10.clCreateContext(properties, handle, null, 0, result);
-            if (result.get(0) != CL10.CL_SUCCESS) throw new RuntimeException("clCreateContext failed: " + result.get(0));
+            if (result.get(0) != CL10.CL_SUCCESS) throw new SiliconException("clCreateContext failed: " + result.get(0));
 
             return new CLContext(context, handle);
         }

--- a/silicon-opencl/src/main/java/org/silicon/opencl/kernel/CLProgram.java
+++ b/silicon-opencl/src/main/java/org/silicon/opencl/kernel/CLProgram.java
@@ -2,6 +2,7 @@ package org.silicon.opencl.kernel;
 
 import org.lwjgl.opencl.CL10;
 import org.lwjgl.system.MemoryStack;
+import org.silicon.api.SiliconException;
 import org.silicon.api.function.ComputeFunction;
 import org.silicon.api.function.ComputeModule;
 
@@ -15,7 +16,7 @@ public record CLProgram(long handle, long device) implements ComputeModule {
             IntBuffer result = stack.mallocInt(1);
             
             long kernel = CL10.clCreateKernel(handle, name, result);
-            if (result.get(0) != CL10.CL_SUCCESS) throw new RuntimeException("clCreateKernel failed: " + result.get(0));
+            if (result.get(0) != CL10.CL_SUCCESS) throw new SiliconException("clCreateKernel failed: " + result.get(0));
             
             return new CLKernel(kernel, device);
         }

--- a/silicon-test/src/test/java/org/silicon/MatMul.java
+++ b/silicon-test/src/test/java/org/silicon/MatMul.java
@@ -1,7 +1,6 @@
 package org.silicon;
 
 import org.silicon.api.Silicon;
-import org.silicon.api.backend.BackendType;
 import org.silicon.api.device.*;
 import org.silicon.api.function.ComputeFunction;
 import org.silicon.api.function.ComputeModule;
@@ -25,8 +24,6 @@ public class MatMul {
     public static void main(String[] args) {
         System.err.println("Warning: This test allocates large GPU buffers");
         System.out.println("Chosen backend: " + Silicon.backend().name());
-
-        Silicon.chooseBackend(BackendType.CUDA);
 
         ComputeDevice device = Silicon.createDevice();
         ComputeContext context = device.createContext();

--- a/silicon-test/src/test/java/org/silicon/MatMul.java
+++ b/silicon-test/src/test/java/org/silicon/MatMul.java
@@ -1,6 +1,7 @@
 package org.silicon;
 
 import org.silicon.api.Silicon;
+import org.silicon.api.backend.BackendType;
 import org.silicon.api.device.*;
 import org.silicon.api.function.ComputeFunction;
 import org.silicon.api.function.ComputeModule;
@@ -24,6 +25,8 @@ public class MatMul {
     public static void main(String[] args) {
         System.err.println("Warning: This test allocates large GPU buffers");
         System.out.println("Chosen backend: " + Silicon.backend().name());
+
+        Silicon.chooseBackend(BackendType.CUDA);
 
         ComputeDevice device = Silicon.createDevice();
         ComputeContext context = device.createContext();


### PR DESCRIPTION
- Make ComputeBackend volatile in Silicon for thread safety
- Use Files.exists(path) instead of new File(path).exists()
- Fix ComputeArena#close() to close in reverse order for proper dependency handling
- Return immutable list from ComputeArgs#getArgs()
- Replace RuntimeException with SiliconException in SlangCompiler and CudaContext
- Define type sizes as constants in CudaContext